### PR TITLE
Add ACT TAC requirements and README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# TAC
-Automating Compliance Tooling Project - Technical Advisory Council
+# [Automating Compliance Tooling (ACT)](https://automatecompliance.org/)
+Our mission is to support development of open source tooling for efficient and effective exchange of software bill of materials (SBOM) to enable license compliance, security, export control, pedigree and provenance workflows.
+
+## Current Projects under the ACT umbrella
+
+Projects under the ACT umbrella are governed by Linux Foundation governance or charters. Current ACT Umbrella Projects include:
+
+* [FOSSology](https://www.fossology.org/)
+* [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort)
+* [SPDX Tools](https://github.com/spdx/tools)
+* [Tern](https://github.com/tern-tools/tern)
+* [QMSTR](https://qmstr.org/)
+
+## ACT Affiliate Projects
+
+Affiliate projects are ACT projects not under Linux Foundation governance or charters. Current Affiliate Projects include:
+
+* [ScanCode](https://github.com/nexB/scancode-toolkit)
+* [REUSE](https://reuse.software/)
+
+## ACT Incubating Projects
+
+Incubating projects are incubating to become regular projects under the ACT umbrella and will be governed by Linux Foundation governance or charters. Current Incubating Projects include:
+
+* [Decoder Ring](https://github.com/DanBeard/DecoderRIng)
+
+
+# ACT Technical Advisory Committee (TAC)
+The role of the ACT TAC is to facilitate communication and collaboration among the Technical Projects underneath the ACT project umbrella. The TAC governing body meets every other week to discuss interoperability and usability of open source compliance toolingas well as general developments in the SBOM and compliance space.

--- a/TAC-Requirements.md
+++ b/TAC-Requirements.md
@@ -1,0 +1,52 @@
+# Requirements to join ACT
+The following document outlines requirements for projects interested in joining the Automating Compliance Tooling Project umbrella. All ACT umbrella projects are required to participate in bi-monthly Technical Advisory Committee (TAC) calls. ACT projects and affiliate projects maintain one vote in all TAC voting body decisions.
+
+## General Criteria for non-affiliate projects to join the ACT umbrella
+* Willingness to generate/consume/interoperate with [SPDX](https://spdx.dev/).
+* Formal project technical charter in place approved by the Linux Foundation. 
+* The software for the project must be licensed under an [OSI approved license](https://opensource.org/licenses).
+* Project must be 100% open source (i.e. not a vendor onramp tool).
+* Must be usable without a commercial component or without a downgraded user experience if not using proprietary software (i.e. proprietary database tie-ins).
+* Data source neutrality must be possible (i.e. tool must not be tied to one particular vendor and must be able to access other data sources).
+* Proprietary plugins are OK but must not be the only mode of operation.
+
+## Criteria to become an Incubating Project
+* Support for SPDX.
+    * If SBOM producing tool, assumption is that tool produces valid SPDX documents
+    * If consumption tool, assumption is that tool is able to consume valid SPDX documents
+* Formal project technical charter in place approved by the Linux Foundation. 
+* "Proof of concept" tools  are ok i.e. not fully functional tools that might aim to solve a larger ecosystem problem.
+* The software for the project must be licensed under an OSI approved license.
+* Data source neutrality must be possible.
+* Source code must be publicly available.
+* How to contribute to the project is documented.
+* Prior to being an incubation project, a presentation will be made to TAC members discussing the general usefulness of the tool and demonstrating how it works as well as any other relevant information (project roadmap, etc).
+* One ACT TAC project member must be willing to “sponsor” and act as a liason on behalf of the incubating project.
+* Note: Incubating projects do not receive an ACT TAC vote until they have graduated to a regular project status.
+
+## Criteria to become an Affiliate Project
+* Support for SPDX.
+    * If SBOM producing tool, assumption is that tool produces valid SPDX documents
+    * If consumption tool, assumption is that tool is able to consume valid SPDX documents
+* Data source neutrality must be possible.
+* Project/tool is established and fully functional (not proof of concepts).
+* The software for the project must be licensed under an OSI approved license.
+* Presentation to TAC members showing how the tool works amd its overall usefulness/completeness.
+* At least one ACT project member endorsement, and willing to “sponsor”.
+* TAC members may not sponsor a project for which they have a clear conflict of interest (for example, originating primarily from their organization). This doesn’t mean that they can’t have any involvement at all - for example, contributing pull requests, or being an end user of that project, can signal a healthy interest in and knowledge of a worthwhile project.
+* TAC vote to accept through a two-thirds vote of the TAC and raised by liaison.
+* Project has a code of conduct and has demonstrated it is a welcoming environment.
+
+## Criteria to Graduate from Incubating to TAC Project/TAC voting member
+* Project has been in incubating stage at least 6 months
+* Incubating project maintainers will participate in a TAC meeting for discussion and Q&A. Any resulting action items are addressed.
+* The project has multiple participants and code development beyond original contribution.
+* Formal governance in place meeting Linux Foundation governance requirements.
+* TAC vote to accept out of incubating status through a two-thirds vote of the TAC.
+* Sponsor has verified that the project has sufficiently demonstrated the project to be usable and substantial.
+* The project demonstrates CII best practices (vulnerability handling, etc.) and maintains a passing criteria.
+* Project has a code of conduct and has demonstrated it is a welcoming environment for contributors.
+
+# Revocation Policy
+* When any of the general criteria no longer applies, the project will be given a warning. After a 6 month warning of inaction on behalf of the project, the TAC will hold a vote (requiring two thirds consensus) to remove the project from its current status and revoke TAC voting privileges.
+


### PR DESCRIPTION
This commit adds information about the requirements to join ACT and ACT
TAC at various stages of a project (i.e. incubating or affiliate). It
also adds info to the README about the current projects that are a part
of ACT.

Signed-off-by: Rose Judge <rjudge@vmware.com>