### PR TITLE
Update Incubating Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Affiliate projects are ACT projects not under Linux Foundation governance or cha
 
 Incubating projects are incubating to become regular projects under the ACT umbrella and will be governed by Linux Foundation governance or charters. Current Incubating Projects include:
 
-* [Decoder Ring](https://github.com/DanBeard/DecoderRIng)
+* [K8s BOM Tool](https://github.com/kubernetes/release/blob/master/cmd/bom/README.md)
 
 
 # ACT Technical Advisory Committee (TAC)


### PR DESCRIPTION
This commit removes Decoder Ring as an ACT incubating project and adds
the K8s BOM Tool. This was voted on by the TAC at the 11/17/2021
meeting.

Signed-off-by: Rose Judge <rjudge@vmware.com>