### PR TITLE
Update K8s bom tool links to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Affiliate projects are ACT projects not under Linux Foundation governance or cha
 
 Incubating projects are incubating to become regular projects under the ACT umbrella and will be governed by Linux Foundation governance or charters. Current Incubating Projects include:
 
-* [K8s BOM Tool](https://github.com/kubernetes/release/blob/master/cmd/bom/README.md)
+* [K8s BOM Tool](https://github.com/kubernetes-sigs/bom)
 
 
 # ACT Technical Advisory Committee (TAC)


### PR DESCRIPTION
The Kubernetes sbom generator was recently moved to a separate project
of its own. This PR updates the link to the new location.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>