### PR TITLE
Remove QMSTR project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Projects under the ACT umbrella are governed by Linux Foundation governance or c
 * [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort)
 * [SPDX Tools](https://github.com/spdx/tools)
 * [Tern](https://github.com/tern-tools/tern)
-* [QMSTR](https://qmstr.org/)
 
 ## ACT Affiliate Projects
 


### PR DESCRIPTION
The QMSTR project is no longer under active development. Per ACT TAC
requirements, it is no longer eligible to be an ACT project.

A TAC vote on February 26th confirmed the removal of this project.

Signed-off-by: Rose Judge <rjudge@vmware.com>